### PR TITLE
Don't use cache when building image

### DIFF
--- a/builddocker
+++ b/builddocker
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker build -t staging-docker.byte.nl/prov/byte-debian:wheezy .
+docker build --no-cache -t staging-docker.byte.nl/prov/byte-debian:wheezy .


### PR DESCRIPTION
This prevents the `apt-get update` from being cached.

Actually, on each package change in our repo I'd like `builddocker && docker push staging-docker.byte.nl/prov/byte-debian:wheezy` to be executed automatically.
